### PR TITLE
Support Pydantic Model parameters with postponed evaluation

### DIFF
--- a/llm_easy_tools/schema_generator.py
+++ b/llm_easy_tools/schema_generator.py
@@ -74,7 +74,9 @@ def parameters_basemodel_from_function(function: Callable) -> Type[pd.BaseModel]
             type_ = parameter.annotation.__args__[0]
         default = PydanticUndefined if parameter.default is inspect.Parameter.empty else parameter.default
         fields[name] = (type_, pd.Field(default, description=description))
-    return pd.create_model(f'{function.__name__}_ParameterModel', **fields)
+    model = pd.create_model(f'{function.__name__}_ParameterModel', **fields)
+    model.model_rebuild()
+    return model
 
 
 def _recursive_purge_titles(d: Dict[str, Any]) -> None:
@@ -245,4 +247,3 @@ if __name__ == "__main__":
         altered_function,
         User
         ]))
-

--- a/tests/schema_generator_test.py
+++ b/tests/schema_generator_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from typing import List, Optional, Union, Literal, Annotated


### PR DESCRIPTION
Related to #4

Address issue with Pydantic Model parameters and postponed evaluation.

* **llm_easy_tools/schema_generator.py**
  - Call `model_rebuild()` on the generated model in `parameters_basemodel_from_function` to handle postponed evaluation.

* **tests/schema_generator_test.py**
  - Add `from __future__ import annotations` to the test file.
  - Verify that the test case for the `search` function with `Query` Pydantic model passes without errors.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zby/LLMEasyTools/issues/4?shareId=313df377-22f3-41d3-98b6-b52c36ca955d).